### PR TITLE
Use NewfoldLabs instead of Endurance for dependency import

### DIFF
--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -3,7 +3,7 @@ namespace Bluehost\WP\Data;
 
 use Bluehost\AccessToken;
 use Bluehost\SiteMeta;
-use Endurance\WP\Module\Data\Helpers\Transient;
+use NewfoldLabs\WP\Module\Data\Helpers\Transient;
 
 /**
  * Helper class for gathering and formatting customer data


### PR DESCRIPTION
## Proposed changes

The change to newfold-labs/wp-module-data requires an `use` change in Customer.php which was still referencing the older endurance module.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
