### PR TITLE
Add filter to append site id to core data

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 use Bluehost\WP\Data\Customer;
+use Bluehost\SiteMeta;
 
 if ( function_exists( 'add_action' ) ) {
 	add_action( 'after_setup_theme', 'bluehost_register_data_package' );
@@ -9,18 +10,26 @@ if ( function_exists( 'add_action' ) ) {
  * Register the customer data module
  */
 function bluehost_register_data_package() {
-	
+
 	// add filter callback to add customer data
 	add_filter( 'newfold_wp_data_module_cron_data_filter', 'bluehost_data_cron_callback' );
+
+	// Add filter callback to add site_id to core data
+	add_filter( 'newfold_wp_data_module_core_data_filter', 'bluehost_append_site_id' );
 }
 
 /**
  * Filter the cron event data object with bluehost specific customer data
- * 
+ *
  * @param array $data prepared to send in the cron event
  * @return array filtered data to send in the cron event
  */
 function bluehost_data_cron_callback( $data ) {
 	$data['customer'] = Customer::collect();
+	return $data;
+}
+
+function bluehost_append_site_id( $data ) {
+	$data['site_id'] = SiteMeta::get_id();
 	return $data;
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     },
     "require": {
-        "newfold-labs/wp-module-data": "^2.0"
+        "newfold-labs/wp-module-data": "^2.2"
     },
     "require-dev": {
         "bluehost/wp-php-standards": "^1.1"


### PR DESCRIPTION
Pending [the addition of the filter on the data module](https://github.com/newfold-labs/wp-module-data/pull/3), this would append the `site_id` value to the core data sent with each event to the Hiive.

