### PR TITLE
Fix/cdata throttling on ajax requests

### DIFF
--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -222,8 +222,8 @@ class Customer {
 			return;
 		}
 
-		// bail to avoid throttling customer endpoint when cant access token
-		if ( self::cant_access_token() ) {
+		// bail to avoid throttling customer endpoint when can not access token
+		if ( ! self::can_access_token() ) {
 			return;
 		}
 
@@ -257,25 +257,26 @@ class Customer {
 	}
 
 	/**
-	 * Check if maybe_refresh_token will not retrieve a valid token
+	 * Check if maybe_refresh_token will retrieve a valid token
 	 * matching logic in Bluehost/AccessToken class for maybe_refresh_token
 	 *
 	 * @return bool
 	 */
-	private static function cant_access_token() {
+	private static function can_access_token() {
 
-		// Bail if this is an ajax request
+		// Is this is an ajax request
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			// Unable to acquire AccessToken on ajax requests
-			return true;
+			return false;
 		}
 
-		// Bail, don't attempt to get a token when it will auto-fail
+		// Does user have permissions or is this cron?
 		if ( ! ( current_user_can( 'manage_options' ) || wp_doing_cron() ) ) {
 			// Unable to acquire AccessToken either without user priveledges or for cron events
-			return true;
+			return false;
 		}
 
+		return true;
 	}
 
 	/**

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -271,12 +271,8 @@ class Customer {
 		}
 
 		// Does user have permissions or is this cron?
-		if ( ! ( current_user_can( 'manage_options' ) || wp_doing_cron() ) ) {
-			// Unable to acquire AccessToken either without user priveledges or for cron events
-			return false;
-		}
-
-		return true;
+		// Unable to acquire AccessToken either without user priveledges or for cron events
+		return ( current_user_can( 'manage_options' ) || wp_doing_cron() );
 	}
 
 	/**

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -55,7 +55,7 @@ class Customer {
 	/**
 	 * Collect customer data
 	 *
-	 * @return array of customer data or false if none
+	 * @return array of customer data
 	 */
 	public static function collect() {
 
@@ -86,12 +86,12 @@ class Customer {
 					! array_key_exists( 'plan_subtype', $data ) 
 				)
 			) {
-				$data = false;
+				$data = array();
 				Transient::delete( self::CUST_DATA ); // delete malformed transient data
 			}
 
 			// valid data found as transient
-			if ( $data ) {
+			if ( ! empty( $data ) ) {
 				// migrate transient data to option
 				self::save_data( $data );
 				Transient::delete( self::CUST_DATA ); // delete transient when data migrated to option

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -223,7 +223,7 @@ class Customer {
 		}
 
 		// bail to avoid throttling customer endpoint when can not access token
-		if ( ! self::can_access_token() ) {
+		if ( ! AccessToken::should_refresh_token() ) {
 			return;
 		}
 
@@ -254,25 +254,6 @@ class Customer {
 
 		self::clear_throttle();
 		return json_decode( wp_remote_retrieve_body( $response ) );
-	}
-
-	/**
-	 * Check if maybe_refresh_token will retrieve a valid token
-	 * matching logic in Bluehost/AccessToken class for maybe_refresh_token
-	 *
-	 * @return bool
-	 */
-	private static function can_access_token() {
-
-		// Is this is an ajax request
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-			// Unable to acquire AccessToken on ajax requests
-			return false;
-		}
-
-		// Does user have permissions or is this cron?
-		// Unable to acquire AccessToken either without user priveledges or for cron events
-		return ( current_user_can( 'manage_options' ) || wp_doing_cron() );
 	}
 
 	/**

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -22,7 +22,7 @@ class Customer {
 	 *
 	 * @var string
 	 */
-	private const CUST_DATA_EXP = 'bh_cdata_expiry';
+	private const CUST_DATA_EXP = 'bh_cdata_expiration';
 
 	/**
 	 * Retry throttle.
@@ -55,7 +55,7 @@ class Customer {
 	/**
 	 * Collect customer data
 	 *
-	 * @return array of customer data
+	 * @return array of customer data or false if none
 	 */
 	public static function collect() {
 
@@ -73,9 +73,8 @@ class Customer {
 			return $data; // return data
 		}
 
-		// Legacy - deal with Transient
-
-		// if no option found, check for transient (legacy)
+		// If no option found, check for transient value
+		// Get legacy data from Transient value 
 		if ( empty( $data ) ) {
 			$data = Transient::get( self::CUST_DATA );
 
@@ -99,7 +98,7 @@ class Customer {
 			}
 		}
 
-		// still empty - no option, and no transient
+		// data is still empty (not found as option, or valid transient), Fetch it
 		if ( empty( $data ) ) {
 			self::refresh_data();
 		}
@@ -112,8 +111,11 @@ class Customer {
 	 *
 	 */
 	private static function refresh_data() {
+		
 		// get account info
 		$guapi = self::get_account_info();
+
+		// bail if no data
 		if ( empty( $guapi ) ) {
 			return;
 		}

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -218,7 +218,7 @@ class Customer {
 		}
 
 		// Bail if this is an ajax request
-		// Unable to aquire AccessToken on ajax requests
+		// Unable to acquire AccessToken on ajax requests
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return;
 		}

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -215,6 +215,13 @@ class Customer {
 			return $provided;
 		}
 
+		// Bail if this is an ajax request
+		// Unable to aquire AccessToken on ajax requests
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return;
+		}
+
+		// bail if throttled
 		if ( self::is_throttled() ) {
 			return;
 		}


### PR DESCRIPTION
## Proposed changes

Since we are unable to acquire AccessToken on ajax requests, bail in the connect method when we're doing ajax. This will still return the data if it's available, but will not attempt to connect when ajaxing.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
