### PR TITLE
Add a fallback to check Hiive when missing a customer ID from cdata

### DIFF
--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -92,6 +92,7 @@ class Customer {
 							$data['customer_id'] = Arr::get( $data, 'customer_id' );
 							update_option( self::CUST_DATA, $data );
 						} else {
+							delete_option( self::CUST_DATA );
 							self::refresh_data();
 						}
 					}

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -88,8 +88,12 @@ class Customer {
 					$body = wp_remote_retrieve_body( $response );
 					$data = json_decode( $body, true );
 					if ( $data && is_array( $data ) ) {
-						$data['customer_id'] = Arr::get( $data, 'customer_id' );
-						update_option( self::CUST_DATA, $data );
+						if ( ! empty( $data ) ) {
+							$data['customer_id'] = Arr::get( $data, 'customer_id' );
+							update_option( self::CUST_DATA, $data );
+						} else {
+							self::refresh_data();
+						}
 					}
 				}
 			}

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -73,7 +73,7 @@ class Customer {
 				self::refresh_data();
 			}
 
-			if ( empty( $data['customer_id'] ) && Str::contains(site_url(), 'temp.domains') ) {
+			if ( empty( $data['customer_id'] ) && ! Str::contains(site_url(), 'temp.domains') ) {
 				$response = wp_remote_get(
 					NFD_HIIVE_URL . '/sites/v1/customer',
 					array(

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -4,6 +4,8 @@ namespace Bluehost\WP\Data;
 use Bluehost\AccessToken;
 use Bluehost\SiteMeta;
 use NewfoldLabs\WP\Module\Data\Helpers\Transient;
+use NewfoldLabs\WP\Module\Data\HiiveConnection;
+use WP_Forge\Helpers\Arr;
 
 /**
  * Helper class for gathering and formatting customer data
@@ -69,21 +71,42 @@ class Customer {
 			if ( self::is_stale() ) {
 				self::refresh_data();
 			}
-			
+
+			if ( empty( $data['customer_id'] ) ) {
+				$response = wp_remote_get(
+					NFD_HIIVE_URL . '/sites/v1/customer',
+					array(
+						'headers' => array(
+							'Content-Type'  => 'application/json',
+							'Accept'        => 'application/json',
+							'Authorization' => 'Bearer ' . HiiveConnection::get_auth_token(),
+						),
+					)
+				);
+				if ( ! is_wp_error( $response ) ) {
+					$body = wp_remote_retrieve_body( $response );
+					$data = json_decode( $body, true );
+					if ( $data && is_array( $data ) ) {
+						$data['customer_id'] = Arr::get( $data, 'customer_id' );
+						update_option( self::CUST_DATA, $data );
+					}
+				}
+			}
+
 			return $data; // return data
 		}
 
 		// If no option found, check for transient value
-		// Get legacy data from Transient value 
+		// Get legacy data from Transient value
 		if ( empty( $data ) ) {
 			$data = Transient::get( self::CUST_DATA );
 
 			// check if transient data is malformed
 			if ( $data &&
 				is_array( $data ) &&
-				( 
+				(
 					! array_key_exists( 'signup_date', $data ) ||
-					! array_key_exists( 'plan_subtype', $data ) 
+					! array_key_exists( 'plan_subtype', $data )
 				)
 			) {
 				$data = array();
@@ -111,7 +134,7 @@ class Customer {
 	 *
 	 */
 	private static function refresh_data() {
-		
+
 		// get account info
 		$guapi = self::get_account_info();
 
@@ -258,11 +281,11 @@ class Customer {
 
 	/**
 	 * Checks if the expiration option has passed
-	 * 
+	 *
 	 * @return bool
 	 */
 	private static function is_stale() {
-		
+
 		// check cdata expiry - return if not yet soft deleted/expired
 		$expiry = \get_option( self::CUST_DATA_EXP, false );
 

--- a/includes/Customer.php
+++ b/includes/Customer.php
@@ -6,6 +6,7 @@ use Bluehost\SiteMeta;
 use NewfoldLabs\WP\Module\Data\Helpers\Transient;
 use NewfoldLabs\WP\Module\Data\HiiveConnection;
 use WP_Forge\Helpers\Arr;
+use WP_Forge\Helpers\Str;
 
 /**
  * Helper class for gathering and formatting customer data
@@ -72,7 +73,7 @@ class Customer {
 				self::refresh_data();
 			}
 
-			if ( empty( $data['customer_id'] ) ) {
+			if ( empty( $data['customer_id'] ) && Str::contains(site_url(), 'temp.domains') ) {
 				$response = wp_remote_get(
 					NFD_HIIVE_URL . '/sites/v1/customer',
 					array(


### PR DESCRIPTION
When `bh_cdata` exists, but is missing a `customer_id` value, then fall back to making a request to Hiive to retrieve just that value and then updating the option to save it with the `customer_id`.

I have not adequately tested this yet. We will still need to test this against the actual Hiive endpoint once we have that deployed. 